### PR TITLE
Correction for MPI compilation

### DIFF
--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -480,9 +480,9 @@ void Simulation::buildTipGridInteractions() {
 
     // Communicate the data to all processes
 #if MPI_BUILD
-    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(fg.forces_.data()),
+    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(forces_.data()),
                   total_points * sizeof(Vec3d), MPI_CHAR, MPI_SUM, universe);
-    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(fg.energies_.data()),
+    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(energies_.data()),
                   total_points, MPI_DOUBLE, MPI_SUM, universe);
 #endif
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -480,9 +480,9 @@ void Simulation::buildTipGridInteractions() {
 
     // Communicate the data to all processes
 #if MPI_BUILD
-    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(forces_.data()),
+    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(forces.data()),
                   total_points * sizeof(Vec3d), MPI_CHAR, MPI_SUM, universe);
-    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(energies_.data()),
+    MPI_Allreduce(MPI_IN_PLACE, static_cast<void*>(energies.data()),
                   total_points, MPI_DOUBLE, MPI_SUM, universe);
 #endif
 


### PR DESCRIPTION
It looks like this was left behind during the update to the class. After this change, the MPI version will be able to compile.